### PR TITLE
Update stgvis.Rmd

### DIFF
--- a/vignettes/stgvis.Rmd
+++ b/vignettes/stgvis.Rmd
@@ -1,10 +1,11 @@
 <!--
 %\VignetteEngine{knitr::knitr}
-%\VignetteIndexEntry{Spatial and spatio-temporal objects in google charts}
+%\VignetteIndexEntry{Spatial and spatio-temporal objects in Google charts}
 -->
+
 # Spatial and spatio-temporal objects in google charts
-======================================================
-This vignette shows how google charts can be used to
+
+This vignette shows how Google charts can be used to
 display some spatio-temporal data sets used in the
 [JSS paper](http://www.jstatsoft.org/v51/i07/) on
 [spacetime](http://cran.r-project.org/package=spacetime).
@@ -12,9 +13,9 @@ display some spatio-temporal data sets used in the
 [Google
 charts](https://developers.google.com/chart/interactive/docs/index)
 are interactive graphs in web pages
-that use google proprietary code. R pachage
+that use Google proprietary code. R package
 [googleVis](http://cran.r-project.org/package=googleVis) converts
-R data.frame objects into google charts. This vignette uses
+R data.frame objects into Google charts. This vignette uses
 [knitr](http://cran.r-project.org/package=knitr) and markdown to
 create a web page from the R-markdown [source file](https://github.com/edzer/spacetime/blob/master/vignettes/stgvis.Rmd). It
 was inspired by, and copies small sections of, the corresponding
@@ -32,74 +33,96 @@ Following plot statements for `gvis` objects will automatically return
 the HTML required for the 'knitted' output.
 
 ## Geo Charts
+
 Geo charts work with country or region (state,
 administrative regions, e.g. NUTS1, formally [ISO
 3166-2](http://en.wikipedia.org/wiki/ISO_3166-2)) data. We will
 try to make the DE_NUTS1 data in spacetime ready for this.
-We read the table with names and codes, using help from
-[stackoverflow](http://stackoverflow.com/questions/1395528/):
-```{r results='asis', eval=FALSE}
-library(XML)
-url = "http://en.wikipedia.org/wiki/ISO_3166-2:DE"
-ISO_3166_2_DE <- readHTMLTable(url, stringsAsFactors = FALSE)[[1]]
+
+### ISOCodes data set from CRAN
+ISOcodes are available from CRAN, including a mapping to German states:
+```{r results='asis', eval=TRUE}
+library(ISOcodes)
+data("ISO_3166_2")
+## State names are already in German
+ISO_3166_2_DE <- subset(ISO_3166_2, Country %in% "DE")
+plot(
+  gvisTable(ISO_3166_2_DE)
+  )
 ```
 
+
+We load the two data sets `rural` and `DE_NUTS1` from the spacetime package and
+add the German state names.
 ```{r results='asis'}
 library(spacetime)
 data(air) # loads rural and DE_NUTS1
-Tbl <- gvisTable(ISO_3166_2_DE, options=list(width=400))
-plot(Tbl)
+ISO_3166_2_DE <- ISO_3166_2_DE[order(ISO_3166_2_DE$Name),]
+DE_NUTS1$name <- ISO_3166_2_DE$Name
 ```
-Luckily, the regions in `DE_NUTS` are in the same (alphabetical) order
-as in the table downloaded from wikipedia, so we can simply copy them 
-without need for matching. We will correct the two bilangual entries:
-```{r}
-DE_NUTS1$name = ISO_3166_2_DE[,2]
-DE_NUTS1$name[2] = "Bayern"        # Not: "Bayern (Bavaria)"
-DE_NUTS1$name[9] = "Niedersachsen" # Not: "Niedersachsen (Lower Saxony)"
-```
+
 Plotting `Shape_Area`, a variable present for all regions in `DE_NUTS1`:
 ```{r GeoMapExample, results='asis', tidy=FALSE}
 library(googleVis)
-M = gvisGeoMap(DE_NUTS1@data, locationvar = "name", numvar = "Shape_Area",
-	options=list(region="DE"))
-plot(M)
+## Create list with options for Geo Chart to be used
+geoChartDE <- list(region="DE", 
+                   resolution="provinces",
+                   legend="{numberFormat:'#,###.00'}") 
+plot(
+  gvisGeoChart(DE_NUTS1@data, locationvar = "name", 
+               colorvar = "Shape_Area",
+               options=geoChartDE)
+  )
 ```
-reveals that Brandenburg is not recognized!  We will now try with
+reveals that Brandenburg is [not recognized](https://code.google.com/p/google-visualization-api-issues/issues/detail?id=707)!  We will now try with
 the ISO 3166-2 codes:
 ```{r results='asis'}
-DE_NUTS1$code = ISO_3166_2_DE[,1]
-M = gvisGeoMap(DE_NUTS1@data, locationvar = "code", numvar = "Shape_Area",
-	options=list(region="DE"))
-plot(M)
+DE_NUTS1$code = ISO_3166_2_DE$Code
+plot(
+  gvisGeoChart(DE_NUTS1@data, locationvar = "code", 
+               colorvar = "Shape_Area",
+               options=geoChartDE)
+  )
 ```
 which reveals that we now have all regions displayed. If however, we would
 omit Berlin, as in
 ```{r results='asis'}
 noBerlin = DE_NUTS1[ISO_3166_2_DE[,1] != "DE-BE",]
-M = gvisGeoMap(noBerlin@data, locationvar = "code", numvar = "Shape_Area",
-	options=list(region="DE"))
-plot(M)
+plot(
+  gvisGeoChart(noBerlin@data, locationvar = "code", 
+               colorvar = "Shape_Area",
+               options=geoChartDE)
+  )
 ```
-we see that Brandenburg now includes Berlin. Google, did you miss a hole
-here?
+we see a hole in Brandenburg where Berlin is. 
+
+
 ## An air quality example Geo chart
+
 We can compute yearly average PM10 concentration over each
-of the states:
+of the states and present a map with a table next to it:
+
 ```{r results='asis'}
 DE_NUTS1.years = STF(DE_NUTS1, as.Date(c("2008-01-01", "2009-01-01")))
 agg = aggregate(rural[,"2008::2009"], DE_NUTS1.years, mean, na.rm=TRUE)
 d = agg[,1]@data # select time step one, take attr table of resulting SpatialPolygonsDataFrame object
-d$code = ISO_3166_2_DE[,1] # add region codes
-M = gvisGeoMap(na.omit(d), locationvar = "code", numvar = "PM10",
-	options=list(region="DE",height=350)) # drop NA values for Geo chart
-Tbl <- gvisTable(d, options=list(height=380, width=200))
+d$code = ISO_3166_2_DE$Code # add region codes
+
+M <- gvisGeoChart(na.omit(d), locationvar = "code", 
+                 colorvar = "PM10",
+                 options=c(geoChartDE, height=400)) # drop NA values for Geo chart
+
+## Add German state names for table
+d$code <- ISO_3166_2_DE$Name
+Tbl <- gvisTable(d, options=list(height=400), 
+                 formats=list(PM10="#,###.0"))
 plot(gvisMerge(M, Tbl, horizontal=TRUE))
 ```
 The white states received no value and correspond to `NA` values
 in the R object `d`; they were omitted by the `na.omit` call.
 
 ## Irish wind station mean and standard deviations
+
 The Irish wind data has 12 stations, shown here on a map, colour
 denoting mean wind speed, symbols size its standard deviation:
 ```{r results='asis'}
@@ -112,9 +135,10 @@ m = round(apply(wind,2,mean), 3)
 sd = round(apply(wind,2,sd), 3)
 wind.loc$mean = m[match(wind.loc$Code, names(m))]
 wind.loc$sd = sd[match(wind.loc$Code, names(sd))]
-M <- gvisGeoChart(wind.loc, "yx", "mean", "sd", "Station",
-	options = list(region = "IE"))
-plot(M)
+plot( gvisGeoChart(wind.loc, "yx", "mean", "sd", "Station",
+                   options = list(region = "IE", 
+                                  legend="{numberFormat:'#.00'}"))
+      )
 ```
 
 # Time lines
@@ -134,28 +158,35 @@ time = ISOdate(wind$year+1900, wind$month, wind$day)
 wind.stack = stack(wind[,4:15])
 names(wind.stack) = c("wind_speed", "station")
 wind.stack$time = rep(time, 12)
-M = gvisAnnotatedTimeLine(wind.stack, "time", "wind_speed", "station",
-	options = list(width = "1000px", height = "500px",
-		zoomStartTime=time[length(time)-365], zoomEndTime=max(time)))
-plot(M)
+plot(
+  gvisAnnotatedTimeLine(wind.stack, "time", "wind_speed", "station",
+                        options = list(width = "1000px", 
+                                       height = "500px",
+                                       zoomStartTime=time[length(time)-365], 
+                                       zoomEndTime=max(time)))
+)
 ```
 
 ## Irish wind in a Line Chart
-The LineChart also supports time, and allows for identifying 
+
+The Line Chart also supports time, and allows for identifying 
 separate lines, when clicking the line or the station. It does
 not allow zooming, and does not work well for many observations
 or many lines.
+
 ```{r results='asis'}
 wind$time = time
-M = gvisLineChart(wind[1:200,], "time", names(wind)[4:9])
-plot(M)
+plot(
+  gvisLineChart(wind[1:200,], "time", names(wind)[4:9])
+  )
 ```
 Line charts deal well with gaps in time series:
 ```{r results='asis'}
 wind$time = time
 wind[4:5, 7:9] = NA
-M = gvisLineChart(wind[1:10,], "time", names(wind)[4:9])
-plot(M)
+plot(
+  gvisLineChart(wind[1:10,], "time", names(wind)[4:9])
+  )
 ```
 
 ## Rural PM10 data from spacetime: Annotation Chart
@@ -170,21 +201,26 @@ in time series, and show them as discontinuities in the lines:
 library(spacetime)
 data(air)
 d = as(rural[1:10,"2001"], "data.frame") # daily, 2001
-M = gvisAnnotationChart(d, "time", "PM10", "sp.ID",
-	options = list(width = "1000px", height = "500px"))
-		# zoomStartTime=d$time[1], zoomEndTime=d$time[1]+365))
-plot(M)
+plot(
+  gvisAnnotationChart(d, "time", "PM10", "sp.ID",
+                      options = list(width = "1000px", 
+                                     height = "500px"))
+  # zoomStartTime=d$time[1], zoomEndTime=d$time[1]+365))
+  )
 ```
 The result is still a bit flaky; just try it for the full time series.
 
 # Motion Chart
+
 The following example shows a motion chart of the `Produc` data used
 in the spacetime manual, but does not convert the data. Time is simply
 year (integer).
+
 ```{r MotionChartExample, results='asis', tidy=FALSE}
 data("Produc", package = "plm")
-M <- gvisMotionChart(Produc, "state", "year")
-plot(M)
+plot(
+  gvisMotionChart(Produc, idvar="state", timevar="year")
+)
 ```
 (Please note that the Motion Chart is only displayed when hosted on a
 web server, or if placed in a directory which has been added to the 


### PR DESCRIPTION
I changed the gvisGeoMap statement to gvisGeoChart, as they don't require Flash. Further the Google Geo Charts understand that Berlin is not part of Brandenburg. Unfortunately, Geo Charts don't recognise Brandenburg as a province either, hence the codes become handy again.
The German states names mapping are available via a CRAN package, thus you don't have to download them from Wikipedia. Finally, I added some number formatting to the option setting.
