### PR TITLE
adds support for rbind of single timestamps; improves on rbind of STSDFs

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -11,8 +11,9 @@ rbind.STIDF = function(..., deparse.level = 1) {
 	args = list(...)
 	df = do.call(rbind, lapply(args, function(x) x@data))
 	time = do.call(c, lapply(args, function(x) index(x@time)))
+	endTime = do.call(c, lapply(args, function(x) x@endTime))
 	sp = do.call(rbind, lapply(args, function(x) x@sp))
-	STIDF(sp, time, df)
+	STIDF(sp, time, df, endTime)
 }
 
 rbind.STTDF = function(...) {
@@ -27,16 +28,38 @@ rbind.STFDF = function(..., deparse.level = 1) {
 	n = names(args[[1]]@data)
 	# as(do.call(rbind, lapply(args, function(x) as(x, "STIDF"))), "STFDF")
 	sp = do.call(rbind, lapply(args, function(x) x@sp))
+	# assuming that all STFDF have the same interval length
+	endTime = unique(do.call(c, lapply(args, function(x) x@endTime)))
 	args = lapply(args, function(x) as(x, "xts"))
 	args = do.call(cbind, args)
-	ret = stConstruct(args, sp)
+	ret = stConstruct(args, sp, endTime = endTime)
 	names(ret@data) = n
 	ret
 }
 
-# pretty "lazy" implementation follow:
-
 rbind.STSDF = function(..., deparse.level = 1) {
+	# args = list(...)
+	# as(do.call(rbind, lapply(args, function(x) as(x, "STIDF"))), "STSDF")
 	args = list(...)
-	as(do.call(rbind, lapply(args, function(x) as(x, "STIDF"))), "STSDF")
+	n = names(args[[1]]@data)
+	sp = do.call(rbind, lapply(args, function(x) x@sp))
+	n.times <- sapply(args, function(x) length(index(x@time)))
+	n.locs <- sapply(args, function(x) length(x@sp))
+	  
+	newTime <- unique(do.call(c, lapply(args, function(x) index(x@time))))
+	newTime <- xts(1:length(newTime), newTime)
+	
+	newIndexTime <- unlist(lapply(args, function(x) match(index(x@time)[x@index[,2]], index(newTime))))
+	newIndexSpace <- unlist(lapply(1:length(args), 
+	                               function(i) rep(sum(c(0,n.locs)[1:i])+1:n.locs[i], n.times[i])))
+	newIndex <- cbind(newIndexSpace, newIndexTime)
+	colnames(newIndex) <- NULL
+	# assuming that all STFDF have the same interval length
+	endTime = unique(do.call(c, lapply(args, function(x) x@endTime)))
+	
+	df <- do.call(rbind, lapply(args, function(x) x@data))
+	ret <- STSDF(sp, newTime, df,
+	             newIndex, endTime)
+	names(ret@data) = n
+	ret
 }

--- a/R/bind.R
+++ b/R/bind.R
@@ -54,7 +54,7 @@ rbind.STSDF = function(..., deparse.level = 1) {
 	                               function(i) rep(sum(c(0,n.locs)[1:i])+1:n.locs[i], n.times[i])))
 	newIndex <- cbind(newIndexSpace, newIndexTime)
 	colnames(newIndex) <- NULL
-	# assuming that all STFDF have the same interval length
+	# assuming that all STSDF have the same interval length
 	endTime = unique(do.call(c, lapply(args, function(x) x@endTime)))
 	
 	df <- do.call(rbind, lapply(args, function(x) x@data))

--- a/R/stconstruct.R
+++ b/R/stconstruct.R
@@ -2,7 +2,10 @@ stConstruct = function(x, space, time, SpatialObj = NULL,
 		TimeObj = NULL, crs = CRS(as.character(NA)), interval, endTime) {
 	if (is(x, "xts")) {
 		stopifnot(ncol(x) == length(space))
-		return(STFDF(space, index(x), data.frame(x = as.vector(t(x)))))
+	  if (missing(endTime))
+  		return(STFDF(space, index(x), data.frame(x = as.vector(t(x)))))
+	  stopifnot(length(endTime) == length(index(x)))
+	  return(STFDF(space, index(x), data.frame(x = as.vector(t(x))), endTime))
 	}
 	if (is(x, "matrix"))
 		x = data.frame(x)


### PR DESCRIPTION
I had problems in rbind for the degenerated case where the ST classes only have a single time instance: endTime could obviously not be derived from the inputs.
