### PR TITLE
Replace direct access to tzone attribute

### DIFF
--- a/R/Class-ST.R
+++ b/R/Class-ST.R
@@ -5,8 +5,8 @@ setClass("ST",
 	stopifnot(nrow(object@time) >= 1)
 	stopifnot(nrow(object@time) == length(object@endTime))
 	# do the time zones, if set, match?
-	tz1 = attr(object@time, "tzone")
-	tz2 = attr(object@endTime, "tzone")
+	tz1 = tzone(object@time)
+	tz2 = tzone(object@endTime)
 	tz1.set = (!is.null(tz1) && !nchar(tz1)==0)
 	tz2.set = (!is.null(tz2) && !nchar(tz2)==0)
 	stopifnot(tz1.set == tz2.set)

--- a/R/Class-xts.R
+++ b/R/Class-xts.R
@@ -1,2 +1,14 @@
 setOldClass("xts")
 setOldClass("zoo")
+tzone = function(x, ...) {
+  if (utils::packageVersion("xts") <= "0.11.2") {
+    if (inherits(x, "xts")) {
+      tzoneAttr = attr(xts::.index(x), "tzone")
+    } else {
+      tzoneAttr = attr(x, "tzone")
+    }
+  } else {
+    tzoneAttr = xts::tzone(x, ...)
+  }
+  tzoneAttr
+}

--- a/R/ST-methods.R
+++ b/R/ST-methods.R
@@ -14,7 +14,7 @@ ST = function(sp, time, endTime) {
 	if (any(is.na(index(time))))
 		stop("NA time values not allowed")
 	stopifnot(is(endTime, "POSIXct"))
-	attr(endTime, "tzone") = attr(time, "tzone")
+	attr(endTime, "tzone") = tzone(time)
 	if (any(is.na(endTime)))
 		stop("NA endTime values not allowed")
 	if (is(sp, "SpatialGrid")) {

--- a/R/STFDF-methods.R
+++ b/R/STFDF-methods.R
@@ -73,7 +73,7 @@ as.STFDF.xts = function(from) {
 				if (is(ix, "Date"))
 					xts(unstack(from[,,i, drop = FALSE]), ix)
 				else
-					xts(unstack(from[,,i, drop = FALSE]), ix, tzone = attr(from@time, "tzone"))
+					xts(unstack(from[,,i, drop = FALSE]), ix, tzone = tzone(from@time))
 			}
 		)
 	)
@@ -216,7 +216,7 @@ subs.STF_and_STFDF <- function(x, i, j, ... , drop = is(x, "STFDF")) {
 				if (is(ix, "Date"))
 					x = xts(xs, ix)
 				else
-					x = xts(xs, ix, tzone = attr(x@time, "tzone"))
+					x = xts(xs, ix, tzone = tzone(x@time))
 			}
 		} else {
 			if (length(t) == 1) {

--- a/R/STIDF-methods.R
+++ b/R/STIDF-methods.R
@@ -26,7 +26,7 @@ STIDF = function(sp, time, data, endTime) {
 		sp = sp[o,]
 		endTime = endTime[o]
 		data = data[o,,drop=FALSE]
-		attr(endTime, "tzone") = attr(time, "tzone")
+		attr(endTime, "tzone") = tzone(time)
 	}
 	new("STIDF", STI(sp, time, endTime), data = data)
 }
@@ -67,7 +67,7 @@ as.xts.STIDF = function(x, ...) {
 	if (is(ix, "Date"))
 		xts(x@data, index(x@time))
 	else
-		xts(x@data, index(x@time), tzone = attr(x@time, "tzone"))
+		xts(x@data, index(x@time), tzone = tzone(x@time))
 }
 setAs("STIDF", "xts", function(from) as.xts.STIDF(from))
 
@@ -211,9 +211,9 @@ rbind.STIDF <- function(...) {
 	stopifnot(identicalCRS(dots))
 	# c() drops tzone attribute:
 	time =    do.call(c, lapply(dots, function(x) index(x)))
-	attr(time, "tzone") = attr(index(dots[[1]]@time), "tzone")
+	attr(time, "tzone") = tzone(dots[[1]]@time)
 	endTime = do.call(c, lapply(dots, function(x) x@endTime))
-	attr(endTime, "tzone") = attr(index(dots[[1]]@endTime), "tzone")
+	attr(endTime, "tzone") = tzone(dots[[1]]@endTime)
 	STIDF(
 		sp =      do.call(rbind, lapply(dots, function(x) x@sp)),
 		time =    time,

--- a/R/STSDF-methods.R
+++ b/R/STSDF-methods.R
@@ -178,7 +178,7 @@ subs.STSDF <- function(x, i, j, ... , drop = is(x, "STSDF")) {
 				if (is(ix, "Date"))
 					x = xts(xs, ix)
 				else
-					x = xts(xs, ix, tzone = attr(x@time, "tzone"))
+					x = xts(xs, ix, tzone = tzone(x@time))
         # added index to achieve 
 				# (nrow(x)==length(order.by)) in index() # TG
 			}

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -11,7 +11,7 @@ aggregate_ST_temporal = function(x, by, FUN, ..., simplify = TRUE) {
 		if (is(ix, "Date"))
 			cc = as.Date(cc)
 		if (is(ix, "POSIXt"))
-			cc = as.POSIXct(cc, tz = attr(ix, "tzone"))
+			cc = as.POSIXct(cc, tz = tzone(ix))
 	}
 	d = vector("list", length = ncol(x@data))
 	for (i in 1:length(d)) {

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -140,7 +140,7 @@ setAs("STTDF", "STIDF",
 	function(from) {
 		sp = do.call(rbind, lapply(from@traj, function(x) x@sp))
 		time = do.call(c, lapply(from@traj, index))
-		attr(time, "tzone") = attr(index(from@traj[[1]]), "tzone")
+		attr(time, "tzone") = tzone(from@traj[[1]])
 		endTime = do.call(c, lapply(from@traj, function(x) x@endTime))
 		STIDF(sp, time, from@data, endTime) # reorders there
 	}

--- a/R/stconstruct.R
+++ b/R/stconstruct.R
@@ -30,7 +30,7 @@ stConstruct = function(x, space, time, SpatialObj = NULL,
 			endTime = delta(time)
 		else
 			endTime = as.POSIXct(index(time))
-		attr(endTime, "tzone") = attr(time, "tzone")
+		attr(endTime, "tzone") = tzone(time)
 		return(STIDF(sp[time,], time, x[time, -c(si, ti), drop=FALSE], endTime))
 	} else if (length(space) == 1 && length(time) == 1) {
 		# long format, space indicates index of SpatialObj:
@@ -46,7 +46,7 @@ stConstruct = function(x, space, time, SpatialObj = NULL,
 				if (!missing(interval) && interval)
 					endTime = delta(time)
 			}
-			attr(endTime, "tzone") = attr(time, "tzone")
+			attr(endTime, "tzone") = tzone(time)
 			return(STIDF(SpatialObj, time, x, endTime))
 		} else {
 			sut = sort(unique(x[,time]))
@@ -57,7 +57,7 @@ stConstruct = function(x, space, time, SpatialObj = NULL,
 				if (!missing(interval) && !interval)
 					endTime = as.POSIXct(index(tm))
 			}
-			attr(endTime, "tzone") = attr(tm, "tzone")
+			attr(endTime, "tzone") = tzone(tm)
 			sp = as.character(sort(unique(x[,space])))
 			return(STFDF(SpatialObj[sp], tm, 
 				x[order(x[,time],as.character(x[,space])),], endTime))
@@ -75,7 +75,7 @@ stConstruct = function(x, space, time, SpatialObj = NULL,
 				endTime = index(TimeObj)
 			else
 				endTime = delta(TimeObj)
-			attr(endTime, "tzone") = attr(TimeObj, "tzone")
+			attr(endTime, "tzone") = tzone(TimeObj)
 		}
 		return(STFDF(SpatialObj, TimeObj, xx, endTime))
 	} else if (is.list(space)) { 


### PR DESCRIPTION
It's best to access object attributes using provided methods, instead
of calling attr(x, 'foo'). So xts::indexTZ() should have been used.

The tzone attribute is being removed from the xts object after xts
version 0.11-2, and will only be attached to the index. indexTZ() is
also deprecated and replaced by tzone(), so we shouldn't use indexTZ().

Add a tzone() function that will handle tzone attributes for xts and
POSIXct objects. The xts index had a tzone attribute in xts version
0.8-8, so get the index attribute for xts objects, and the tzone
attribute for POSIXct (or any other) object. Use xts::tzone() if the
loaded xts version is greater than 0.11-2.

See joshuaulrich/xts#245 for details.

Fixes #37.